### PR TITLE
Added meanings option

### DIFF
--- a/duckduckgo.py
+++ b/duckduckgo.py
@@ -30,7 +30,7 @@ def query(query, useragent='python-duckduckgo '+str(__version__), safesearch=Tru
 
     safesearch = '1' if safesearch else '-1'
     html = '0' if html else '1'
-    meanings = '1' if meanings else '0'
+    meanings = '0' if meanings else '1'
     params = {
         'q': query,
         'o': 'json',


### PR DESCRIPTION
This commit adds ability to query just for meanings of queries.
Example:

http://api.duckduckgo.com/?q=apple&format=json&pretty=1&d=0

vs.

http://api.duckduckgo.com/?q=apple&format=json&pretty=1&d=1
