### PR TITLE
Clarify copyright and licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
 BSD-style license
 =================
 
-Copyright (c) 2010, Michael Stephens
+Copyright (c) 2010 Michael Stephens <me@mikej.st>
+Copyright (c) 2012-2013 Michael Smith <crazedpsyc@gshellz.org>
 
 All rights reserved.
 

--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,16 @@ python-duckduckgo
 
 A Python library for querying the DuckDuckGo API.
 
-Copyright Michael Stephens <me@mikej.st>, released under a BSD-style license.
+Copyright (c) 2010 Michael Stephens <me@mikej.st>
+Copyright (c) 2012-2013 Michael Smith <crazedpsyc@gshellz.org>
 
-Source: http://github.com/crazedpsyc/python-duckduckgo
+Released under a 3-clause BSD license, see LICENSE for details.
+
+Latest Source: http://github.com/crazedpsyc/python-duckduckgo
 Original source: http://github.com/mikejs/python-duckduckgo (outdated)
 
-This version has been forked from the original to handle some new features of the API, and switch from XML to JSON.
+This version has been forked from the original to handle some new features of
+the API, and switch from XML to JSON.
 
 Installation
 ============

--- a/duckduckgo.py
+++ b/duckduckgo.py
@@ -1,3 +1,10 @@
+# duckduckgo.py - Library for querying the DuckDuckGo API
+#
+# Copyright (c) 2010 Michael Stephens <me@mikej.st>
+# Copyright (c) 2012-2013 Michael Smith <crazedpsyc@gshellz.org>
+#
+# See LICENSE for terms of usage, modification and redistribution.
+
 import urllib
 import urllib2
 import json as j


### PR DESCRIPTION
Many Linux and BSD-like distributions will find it easier to include
this library in their packaging systems if the copyright and licensing
conditions are clarified.