### PR TITLE
Add instant answer script

### DIFF
--- a/duckduckgo.py
+++ b/duckduckgo.py
@@ -171,6 +171,14 @@ def get_zci(q, web_fallback=True, priority=['answer', 'abstract', 'related.0', '
 
     return response
 
+def ia():
+    if len(sys.argv) > 1:
+        q = get_zci(' '.join(sys.argv[1:]))
+        sys.stdout.write(q)
+        sys.stdout.write('\n')
+    else:
+        print('Usage: %s [query]' % sys.argv[0])
+
 def main():
     if len(sys.argv) > 1:
         q = query(' '.join(sys.argv[1:]))

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(name='duckduckgo2',
                    "Programming Language :: Python",
                    "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
                    ],
-      entry_points={'console_scripts':['ddg = duckduckgo:main']},
+      entry_points={'console_scripts':['ddg = duckduckgo:main',
+                                       'ia = duckduckgo:ia']},
       )


### PR DESCRIPTION
Adds a wrapper function around get_zci to allow querying for
instant answers from the shell.

If you could bump the version after merging this and do a new
upload to PyPI then I'll update the package for Debian.

Version 0.242 is currently sat in the NEW queue:
https://ftp-master.debian.org/new/python-duckduckgo2_0.242-1.html
